### PR TITLE
In both Brandibble.js & Brandibble-Redux, we have a “defaultMiscOptio…

### DIFF
--- a/lib/models/order.js
+++ b/lib/models/order.js
@@ -25,7 +25,8 @@ export default class Order {
     this.creditCard = null;
     this.locationId = location_id;
     this.serviceType = serviceType;
-    this.miscOptions = miscOptions;
+    /* Ensure each object owns it's miscOptions */
+    this.miscOptions = Object.assign({}, miscOptions);
     this.requestedAt = ASAP_STRING;
     this.paymentType = paymentType;
   }

--- a/spec/models/Order.spec.js
+++ b/spec/models/Order.spec.js
@@ -6,6 +6,16 @@ import { validFavoriteForOrder } from '../stubs/favorite.stub';
 import { TestingAddress } from '../helpers';
 
 describe('models/order', () => {
+
+  it('wont allow orders to share the misc object memory allocation', () => {
+    const newOrder = new Brandibble.Order(Brandibble.adapter, locationJSON.location_id, 'pickup');
+    const otherNewOrder = new Brandibble.Order(Brandibble.adapter, locationJSON.location_id, 'pickup');
+    return newOrder.setPromoCode('yolo').then(() => {
+      expect(newOrder.miscOptions).to.not.equal(otherNewOrder.miscOptions);
+      expect(newOrder.miscOptions.promo_code).to.not.equal(otherNewOrder.miscOptions.promo_code);
+    });
+  });
+
   it('can add a LineItem', () => {
     const newOrder = new Brandibble.Order(Brandibble.adapter, locationJSON.location_id, 'pickup');
     newOrder.addLineItem(productJSON);


### PR DESCRIPTION
…ns” object that is set on new orders.  In both cases it’s allocated at the interpret-time rather than the run-time, meaning that they are shared across orders.  This PR ensures all Orders create a new allocation for MiscOptions