### PR TITLE
When working with Brandibble Menu endpoint, it may

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -94,9 +94,21 @@ export default class Adapter {
     return this.storage.getItem('currentOrder').then((serializedOrder) => {
       if (!serializedOrder) return;
 
-      const { locationId, serviceType, miscOptions, requestedAt, cart, paymentType, customer, address, creditCard } = CircularJSON.parse(serializedOrder);
+      const {
+        locationId,
+        serviceType,
+        miscOptions,
+        requestedAt,
+        cart,
+        paymentType,
+        customer,
+        address,
+        creditCard,
+        wantsFutureOrder,
+      } = CircularJSON.parse(serializedOrder);
 
       const order = new Order(this, locationId, serviceType, paymentType, miscOptions);
+      if (wantsFutureOrder) { order.wantsFutureOrder = wantsFutureOrder; }
       if (address) { order.address = address; }
       if (customer) { order.customer = customer; }
       if (paymentType) { order.paymentType = paymentType; }

--- a/lib/models/order.js
+++ b/lib/models/order.js
@@ -29,6 +29,12 @@ export default class Order {
     this.miscOptions = Object.assign({}, miscOptions);
     this.requestedAt = ASAP_STRING;
     this.paymentType = paymentType;
+    /* This is here so that we can internally mark when
+     * a user actually wants a future order, versus the
+     * case when we manually set requested_at because we
+     * were given a future daypart during a Brandibble menu
+     * request cycle. */
+    this.wantsFutureOrder = false;
   }
 
   rehydrateCart(serializedCart = {}) {
@@ -41,18 +47,28 @@ export default class Order {
       lineItem.configuration = configuration;
       lineItem._generateOperationMaps();
     });
-
     return this;
   }
 
-  setRequestedAt(timestampOrAsap = ASAP_STRING) {
+  setRequestedAt(timestampOrAsap = ASAP_STRING, userWantsFutureOrder = false) {
+    if (typeof (userWantsFutureOrder) !== 'boolean') {
+      throw new Error(
+        'Brandibble.js: You must pass a boolean as the second argument (`userWantsFutureOrder`) to `Order#setRequestedAt`.',
+      );
+    }
     if (timestampOrAsap === ASAP_STRING) {
+      if (userWantsFutureOrder) {
+        throw new Error(
+          'Brandibble.js: You can not pass `true` for `userWantsFutureOrder` when setting the Order#requested_at to `asap`.',
+        );
+      }
       this.requestedAt = ASAP_STRING;
       return this.adapter.persistCurrentOrder(this);
     }
 
     const result = validate({ timestamp: timestampOrAsap }, { timestamp: { format: ISO8601_PATTERN } });
     if (!result) {
+      this.wantsFutureOrder = userWantsFutureOrder;
       this.requestedAt = timestampOrAsap;
       return this.adapter.persistCurrentOrder(this);
     }

--- a/spec/adapter.spec.js
+++ b/spec/adapter.spec.js
@@ -39,6 +39,8 @@ describe('Adapter', () => {
 
   it('can restore currentOrder from localStorage', () => {
     return configureTestingOrder(Brandibble).then((order) => {
+      // This is here for testing that this is properly restored... you'd never set it like this in a real app.
+      order.wantsFutureOrder = true;
       return Brandibble.adapter.persistCurrentOrder(order).then(() => {
         return Brandibble.adapter.restoreCurrentOrder().then((retrievedOrder) => {
           expect(order).to.deep.equal(retrievedOrder);

--- a/spec/models/Order.spec.js
+++ b/spec/models/Order.spec.js
@@ -20,6 +20,22 @@ describe('models/order', () => {
     });
   });
 
+  it('can flag a wantsFutureOrder', () => {
+    const newOrder = new Brandibble.Order(Brandibble.adapter, locationJSON.location_id, 'pickup');
+    newOrder.setRequestedAt("2017-06-21T16:09:49Z", true);
+    expect(newOrder.wantsFutureOrder).to.be.true;
+  });
+
+  it('will throw if wantsFutureOrder is not a bool', () => {
+    const newOrder = new Brandibble.Order(Brandibble.adapter, locationJSON.location_id, 'pickup');
+    expect(() => newOrder.setRequestedAt("2017-06-21T16:09:49Z", 'true')).to.throw;
+  });
+
+  it('will throw when setting wantsFutureOrder and asap', () => {
+    const newOrder = new Brandibble.Order(Brandibble.adapter, locationJSON.location_id, 'pickup');
+    expect(() => newOrder.setRequestedAt("asap", true)).to.throw;
+  });
+
   it('can add a LineItem', () => {
     const newOrder = new Brandibble.Order(Brandibble.adapter, locationJSON.location_id, 'pickup');
     newOrder.addLineItem(productJSON);


### PR DESCRIPTION
return a future menu, as denoted by the daypart it
includes in that response. In host apps, we 
automatically assume that the user wants to use that
menu, and set the order’s requested_at to that
daypart. However, if a store is closed, and the user
switches menu, we need a way of discerning when the
user manually requested a future order, versus when
we assumed they do. This flag allows us to do just
that.